### PR TITLE
feat: make `no_std` and add `alloc` feature`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ description = """
 An async, lock-free synchronization primitive for task wakeup.
 """
 categories = ["asynchronous", "concurrency"]
-keywords = ["async", "waker", "atomic", "futures"]
+keywords = ["async", "waker", "atomic", "futures", "no_std", "no_alloc"]
+
+[features]
+default = ["alloc"]
+alloc = []
 
 [target.'cfg(diatomic_waker_loom)'.dependencies]
 waker-fn = "1.1"

--- a/src/arc_waker.rs
+++ b/src/arc_waker.rs
@@ -1,0 +1,92 @@
+use alloc::sync::Arc;
+use core::task::Waker;
+
+use crate::primitives::DiatomicWaker;
+use crate::primitives::WaitUntil;
+
+/// An object that can await a notification from one or several
+/// [`WakeSource`](WakeSource)s.
+///
+/// See the [crate-level documentation](crate) for usage.
+#[derive(Debug, Default)]
+pub struct WakeSink {
+    /// The shared data.
+    inner: Arc<DiatomicWaker>,
+}
+
+impl WakeSink {
+    /// Creates a new sink.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(DiatomicWaker::new()),
+        }
+    }
+
+    /// Creates a new source.
+    #[inline]
+    pub fn source(&self) -> WakeSource {
+        WakeSource {
+            inner: self.inner.clone(),
+        }
+    }
+
+    /// Registers a new waker.
+    ///
+    /// Registration is lazy: the waker is cloned only if it differs from the
+    /// last registered waker (note that the last registered waker is cached
+    /// even if it was unregistered).
+    #[inline]
+    pub fn register(&mut self, waker: &Waker) {
+        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
+        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
+        // thread since `WakeSink` does not implement `Clone` and the wrappers
+        // of the above methods require exclusive ownership to `WakeSink`.
+        unsafe { self.inner.register(waker) };
+    }
+
+    /// Unregisters the waker.
+    ///
+    /// After the waker is unregistered, subsequent calls to
+    /// `WakeSource::notify` will be ignored.
+    #[inline]
+    pub fn unregister(&mut self) {
+        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
+        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
+        // thread since `WakeSink` does not implement `Clone` and the wrappers
+        // of the above methods require exclusive ownership to `WakeSink`.
+        unsafe { self.inner.unregister() };
+    }
+
+    /// Returns a future that can be `await`ed until the provided predicate
+    /// returns a value.
+    ///
+    /// The predicate is checked each time a notification is received.
+    #[inline]
+    pub fn wait_until<P, T>(&mut self, predicate: P) -> WaitUntil<'_, P, T>
+    where
+        P: FnMut() -> Option<T> + Unpin,
+    {
+        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
+        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
+        // thread since `WakeSink` does not implement `Clone` and the wrappers
+        // of the above methods require exclusive ownership to `WakeSink`.
+        unsafe { self.inner.wait_until(predicate) }
+    }
+}
+
+/// An object that can send a notification to a [`WakeSink`](WakeSink).
+///
+/// See the [crate-level documentation](crate) for usage.
+#[derive(Clone, Debug)]
+pub struct WakeSource {
+    /// The shared data.
+    inner: Arc<DiatomicWaker>,
+}
+
+impl WakeSource {
+    /// Notifies the sink if a waker is registered.
+    #[inline]
+    pub fn notify(&self) {
+        self.inner.notify();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,11 +152,11 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "alloc")]
+mod arc_waker;
 pub mod borrowing;
 mod loom_exports;
 pub mod primitives;
-#[cfg(feature = "alloc")]
-pub mod arc_waker;
 
 #[cfg(feature = "alloc")]
 pub use arc_waker::{WakeSink, WakeSource};
@@ -166,6 +166,7 @@ pub use arc_waker::{WakeSink, WakeSource};
 mod tests {
     use super::*;
 
+    use core::task::Waker;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::atomic::Ordering;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@
 //! ```
 //!
 #![warn(missing_docs, missing_debug_implementations, unreachable_pub)]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,103 +147,19 @@
 //! ```
 //!
 #![warn(missing_docs, missing_debug_implementations, unreachable_pub)]
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod borrowing;
 mod loom_exports;
 pub mod primitives;
+#[cfg(feature = "alloc")]
+pub mod arc_waker;
 
-use std::sync::Arc;
-use std::task::Waker;
-
-use primitives::DiatomicWaker;
-use primitives::WaitUntil;
-
-/// An object that can await a notification from one or several
-/// [`WakeSource`](WakeSource)s.
-///
-/// See the [crate-level documentation](crate) for usage.
-#[derive(Debug, Default)]
-pub struct WakeSink {
-    /// The shared data.
-    inner: Arc<DiatomicWaker>,
-}
-
-impl WakeSink {
-    /// Creates a new sink.
-    pub fn new() -> Self {
-        Self {
-            inner: Arc::new(DiatomicWaker::new()),
-        }
-    }
-
-    /// Creates a new source.
-    #[inline]
-    pub fn source(&self) -> WakeSource {
-        WakeSource {
-            inner: self.inner.clone(),
-        }
-    }
-
-    /// Registers a new waker.
-    ///
-    /// Registration is lazy: the waker is cloned only if it differs from the
-    /// last registered waker (note that the last registered waker is cached
-    /// even if it was unregistered).
-    #[inline]
-    pub fn register(&mut self, waker: &Waker) {
-        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
-        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
-        // thread since `WakeSink` does not implement `Clone` and the wrappers
-        // of the above methods require exclusive ownership to `WakeSink`.
-        unsafe { self.inner.register(waker) };
-    }
-
-    /// Unregisters the waker.
-    ///
-    /// After the waker is unregistered, subsequent calls to
-    /// `WakeSource::notify` will be ignored.
-    #[inline]
-    pub fn unregister(&mut self) {
-        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
-        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
-        // thread since `WakeSink` does not implement `Clone` and the wrappers
-        // of the above methods require exclusive ownership to `WakeSink`.
-        unsafe { self.inner.unregister() };
-    }
-
-    /// Returns a future that can be `await`ed until the provided predicate
-    /// returns a value.
-    ///
-    /// The predicate is checked each time a notification is received.
-    #[inline]
-    pub fn wait_until<P, T>(&mut self, predicate: P) -> WaitUntil<'_, P, T>
-    where
-        P: FnMut() -> Option<T> + Unpin,
-    {
-        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
-        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
-        // thread since `WakeSink` does not implement `Clone` and the wrappers
-        // of the above methods require exclusive ownership to `WakeSink`.
-        unsafe { self.inner.wait_until(predicate) }
-    }
-}
-
-/// An object that can send a notification to a [`WakeSink`](WakeSink).
-///
-/// See the [crate-level documentation](crate) for usage.
-#[derive(Clone, Debug)]
-pub struct WakeSource {
-    /// The shared data.
-    inner: Arc<DiatomicWaker>,
-}
-
-impl WakeSource {
-    /// Notifies the sink if a waker is registered.
-    #[inline]
-    pub fn notify(&self) {
-        self.inner.notify();
-    }
-}
+#[cfg(feature = "alloc")]
+pub use arc_waker::{WakeSink, WakeSource};
 
 /// Loom tests.
 #[cfg(all(test, diatomic_waker_loom))]

--- a/src/loom_exports.rs
+++ b/src/loom_exports.rs
@@ -9,7 +9,7 @@ pub(crate) mod sync {
 #[allow(unused_imports)]
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        pub(crate) use std::sync::atomic::AtomicUsize;
+        pub(crate) use core::sync::atomic::AtomicUsize;
     }
 }
 
@@ -20,11 +20,11 @@ pub(crate) mod cell {
 #[cfg(not(diatomic_waker_loom))]
 pub(crate) mod cell {
     #[derive(Debug)]
-    pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
+    pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
 
     impl<T> UnsafeCell<T> {
         pub(crate) const fn new(data: T) -> UnsafeCell<T> {
-            UnsafeCell(std::cell::UnsafeCell::new(data))
+            UnsafeCell(core::cell::UnsafeCell::new(data))
         }
         pub(crate) fn with<R>(&self, f: impl FnOnce(*const T) -> R) -> R {
             f(self.0.get())

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,9 +1,9 @@
 //! Primitives for task wakeup.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::atomic::Ordering;
-use std::task::{Context, Poll, Waker};
+use core::future::Future;
+use core::pin::Pin;
+use core::sync::atomic::Ordering;
+use core::task::{Context, Poll, Waker};
 
 use crate::borrowing::{WakeSinkRef, WakeSourceRef};
 use crate::loom_exports::cell::UnsafeCell;
@@ -53,7 +53,7 @@ const NOTIFICATION: usize = 0b10000;
 /// ensuring that a `WakeSink` cannot be used concurrently from multiple
 /// threads. The only advantage of this primitive is that it does not require
 /// allocation on construction, unlike `WakeSink` and `WakeSource` which store a
-/// shared `DiatomicWaker` within an [`Arc`](std::sync::Arc).
+/// shared `DiatomicWaker` within an [`Arc`](core::sync::Arc).
 #[derive(Debug)]
 pub struct DiatomicWaker {
     /// A bit field for `INDEX`, `UPDATE`, `REGISTERED`, `LOCKED` and `NOTIFICATION`.


### PR DESCRIPTION
Hello, I'm an embedded developer and found this crate. It looks really great, buy we cannot use it as it is not `no_std`. Fortunately, this crate is not using any `std`-specific dependencies, so this is trivial to make it `no_std`. It will not affect any already existing users of this crate, as `no_std` crates can be used with `std` crates together, but will open it for other users to try.