### PR TITLE
feat: add borrowing diatomic-waker

### DIFF
--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -1,0 +1,109 @@
+//! Non-allcating, safe, statically allocated wrapper for `DiatomicWaker`.
+//!
+//! See the [crate-level documentation](crate) for usage.
+
+use std::task::Waker;
+
+use crate::primitives::DiatomicWaker;
+use crate::primitives::WaitUntil;
+
+/// A safe, statically allocated `DiatomicWaker`
+///
+/// See the [crate-level documentation](crate) for usage.
+#[derive(Default, Debug)]
+pub struct BorrowingDiatomicWaker {
+    inner: DiatomicWaker,
+}
+
+/// An object that can await a notification from one or several
+/// [`WakeSource`](WakeSource)s.
+///
+/// See the [crate-level documentation](crate) for usage.
+#[derive(Debug)]
+pub struct WakeSink<'a> {
+    /// The shared data.
+    inner: &'a DiatomicWaker,
+}
+/// An object that can send a notification to a [`WakeSink`](WakeSink).
+///
+/// See the [crate-level documentation](crate) for usage.
+#[derive(Clone, Debug)]
+pub struct WakeSource<'a> {
+    /// The shared data.
+    inner: &'a DiatomicWaker,
+}
+
+impl BorrowingDiatomicWaker {
+    /// Creates [`BorrowingDiatomicWaker`]
+    pub const fn new() -> Self {
+        Self {
+            inner: DiatomicWaker::new(),
+        }
+    }
+    /// Splits to [`WakeSink`] and [`WakeSource`]. Mutably borrows `self`,
+    /// ensuring that multiple [`WakeSink`] to the same [`DiatomicWaker`] are
+    /// impossible
+    pub fn split(&mut self) -> (WakeSink, WakeSource) {
+        let inner = &self.inner;
+        (WakeSink { inner }, WakeSource { inner })
+    }
+}
+
+impl WakeSource<'_> {
+    /// Notifies the sink if a waker is registered.
+    #[inline]
+    pub fn notify(&self) {
+        self.inner.notify();
+    }
+}
+
+impl WakeSink<'_> {
+    /// Creates a new source.
+    #[inline]
+    pub fn source(&self) -> WakeSource {
+        WakeSource { inner: self.inner }
+    }
+
+    /// Registers a new waker.
+    ///
+    /// Registration is lazy: the waker is cloned only if it differs from the
+    /// last registered waker (note that the last registered waker is cached
+    /// even if it was unregistered).
+    #[inline]
+    pub fn register(&mut self, waker: &Waker) {
+        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
+        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
+        // thread since `WakeSink` does not implement `Clone` and the wrappers
+        // of the above methods require exclusive ownership to `WakeSink`.
+        unsafe { self.inner.register(waker) };
+    }
+
+    /// Unregisters the waker.
+    ///
+    /// After the waker is unregistered, subsequent calls to
+    /// `WakeSource::notify` will be ignored.
+    #[inline]
+    pub fn unregister(&mut self) {
+        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
+        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
+        // thread since `WakeSink` does not implement `Clone` and the wrappers
+        // of the above methods require exclusive ownership to `WakeSink`.
+        unsafe { self.inner.unregister() };
+    }
+
+    /// Returns a future that can be `await`ed until the provided predicate
+    /// returns a value.
+    ///
+    /// The predicate is checked each time a notification is received.
+    #[inline]
+    pub fn wait_until<P, T>(&mut self, predicate: P) -> WaitUntil<'_, P, T>
+    where
+        P: FnMut() -> Option<T> + Unpin,
+    {
+        // Safety: `WakePrimitive::register`, `WakePrimitive::unregister` and
+        // `WakePrimitive::wait_until` cannot be used concurrently from multiple
+        // thread since `WakeSink` does not implement `Clone` and the wrappers
+        // of the above methods require exclusive ownership to `WakeSink`.
+        unsafe { self.inner.wait_until(predicate) }
+    }
+}

--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -7,14 +7,6 @@ use std::task::Waker;
 use crate::primitives::DiatomicWaker;
 use crate::primitives::WaitUntil;
 
-/// A safe, statically allocated `DiatomicWaker`
-///
-/// See the [crate-level documentation](crate) for usage.
-#[derive(Default, Debug)]
-pub struct BorrowingDiatomicWaker {
-    inner: DiatomicWaker,
-}
-
 /// An object that can await a notification from one or several
 /// [`WakeSource`](WakeSource)s.
 ///
@@ -22,7 +14,7 @@ pub struct BorrowingDiatomicWaker {
 #[derive(Debug)]
 pub struct WakeSinkRef<'a> {
     /// The shared data.
-    inner: &'a DiatomicWaker,
+    pub(crate) inner: &'a DiatomicWaker,
 }
 /// An object that can send a notification to a [`WakeSink`](WakeSink).
 ///
@@ -30,23 +22,7 @@ pub struct WakeSinkRef<'a> {
 #[derive(Clone, Debug)]
 pub struct WakeSourceRef<'a> {
     /// The shared data.
-    inner: &'a DiatomicWaker,
-}
-
-impl BorrowingDiatomicWaker {
-    /// Creates [`BorrowingDiatomicWaker`]
-    pub const fn new() -> Self {
-        Self {
-            inner: DiatomicWaker::new(),
-        }
-    }
-    /// Splits to [`WakeSink`] and [`WakeSource`]. Mutably borrows `self`,
-    /// ensuring that multiple [`WakeSink`] to the same [`DiatomicWaker`] are
-    /// impossible
-    pub fn split(&mut self) -> (WakeSinkRef, WakeSourceRef) {
-        let inner = &self.inner;
-        (WakeSinkRef { inner }, WakeSourceRef { inner })
-    }
+    pub(crate) inner: &'a DiatomicWaker,
 }
 
 impl WakeSourceRef<'_> {

--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -2,7 +2,7 @@
 //!
 //! See the [crate-level documentation](crate) for usage.
 
-use std::task::Waker;
+use core::task::Waker;
 
 use crate::primitives::DiatomicWaker;
 use crate::primitives::WaitUntil;

--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -1,4 +1,4 @@
-//! Non-allcating, safe, statically allocated wrapper for `DiatomicWaker`.
+//! Non-allocating, safe, statically allocated wrapper for `DiatomicWaker`.
 //!
 //! See the [crate-level documentation](crate) for usage.
 
@@ -20,7 +20,7 @@ pub struct BorrowingDiatomicWaker {
 ///
 /// See the [crate-level documentation](crate) for usage.
 #[derive(Debug)]
-pub struct WakeSink<'a> {
+pub struct WakeSinkRef<'a> {
     /// The shared data.
     inner: &'a DiatomicWaker,
 }
@@ -28,7 +28,7 @@ pub struct WakeSink<'a> {
 ///
 /// See the [crate-level documentation](crate) for usage.
 #[derive(Clone, Debug)]
-pub struct WakeSource<'a> {
+pub struct WakeSourceRef<'a> {
     /// The shared data.
     inner: &'a DiatomicWaker,
 }
@@ -43,13 +43,13 @@ impl BorrowingDiatomicWaker {
     /// Splits to [`WakeSink`] and [`WakeSource`]. Mutably borrows `self`,
     /// ensuring that multiple [`WakeSink`] to the same [`DiatomicWaker`] are
     /// impossible
-    pub fn split(&mut self) -> (WakeSink, WakeSource) {
+    pub fn split(&mut self) -> (WakeSinkRef, WakeSourceRef) {
         let inner = &self.inner;
-        (WakeSink { inner }, WakeSource { inner })
+        (WakeSinkRef { inner }, WakeSourceRef { inner })
     }
 }
 
-impl WakeSource<'_> {
+impl WakeSourceRef<'_> {
     /// Notifies the sink if a waker is registered.
     #[inline]
     pub fn notify(&self) {
@@ -57,11 +57,11 @@ impl WakeSource<'_> {
     }
 }
 
-impl WakeSink<'_> {
+impl WakeSinkRef<'_> {
     /// Creates a new source.
     #[inline]
-    pub fn source(&self) -> WakeSource {
-        WakeSource { inner: self.inner }
+    pub fn source(&self) -> WakeSourceRef {
+        WakeSourceRef { inner: self.inner }
     }
 
     /// Registers a new waker.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,9 @@
 //!
 #![warn(missing_docs, missing_debug_implementations, unreachable_pub)]
 
+pub mod borrowing;
 mod loom_exports;
 pub mod primitives;
-pub mod borrowing;
 
 use std::sync::Arc;
 use std::task::Waker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@
 //! yourself, but will then need to ensure by other means that waker
 //! registration cannot be performed concurrently.
 //!
+//! The API also provides a [`borrowing::BorrowingDiatomicWaker`],
+//! [`borrowing::WakeSink`] and [`borrowing::WakeSource`] that provides a safe,
+//! statically allocated `DiatomicWaker`, but introduces a lifetime.
+//!
 //! [atomic-waker]: https://docs.rs/atomic-waker/latest/atomic_waker/
 //! [eventcount]:
 //!     https://www.1024cores.net/home/lock-free-algorithms/eventcounts
@@ -146,6 +150,7 @@
 
 mod loom_exports;
 pub mod primitives;
+pub mod borrowing;
 
 use std::sync::Arc;
 use std::task::Waker;

--- a/src/loom_exports.rs
+++ b/src/loom_exports.rs
@@ -23,7 +23,7 @@ pub(crate) mod cell {
     pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
 
     impl<T> UnsafeCell<T> {
-        pub(crate) fn new(data: T) -> UnsafeCell<T> {
+        pub(crate) const fn new(data: T) -> UnsafeCell<T> {
             UnsafeCell(std::cell::UnsafeCell::new(data))
         }
         pub(crate) fn with<R>(&self, f: impl FnOnce(*const T) -> R) -> R {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -63,7 +63,16 @@ pub struct DiatomicWaker {
 
 impl DiatomicWaker {
     /// Creates a new `DiatomicWaker`.
+    #[cfg(not(diatomic_waker_loom))]
     pub const fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+            waker: [UnsafeCell::new(None), UnsafeCell::new(None)],
+        }
+    }
+
+    #[cfg(diatomic_waker_loom)]
+    pub fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),
             waker: [UnsafeCell::new(None), UnsafeCell::new(None)],

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -63,7 +63,7 @@ pub struct DiatomicWaker {
 
 impl DiatomicWaker {
     /// Creates a new `DiatomicWaker`.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),
             waker: [UnsafeCell::new(None), UnsafeCell::new(None)],

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::atomic::Ordering;
 use std::task::{Context, Poll, Waker};
 
+use crate::borrowing::{WakeSinkRef, WakeSourceRef};
 use crate::loom_exports::cell::UnsafeCell;
 use crate::loom_exports::sync::atomic::AtomicUsize;
 
@@ -77,6 +78,14 @@ impl DiatomicWaker {
             state: AtomicUsize::new(0),
             waker: [UnsafeCell::new(None), UnsafeCell::new(None)],
         }
+    }
+
+    /// Splits to [`WakeSinkRef`] and [`WakeSourceRef`]. Mutably borrows `self`,
+    /// ensuring that multiple [`WakeSinkRef`] to the same [`DiatomicWaker`] are
+    /// impossible
+    pub fn split(&mut self) -> (WakeSinkRef, WakeSourceRef) {
+        let inner = &*self;
+        (WakeSinkRef { inner }, WakeSourceRef { inner })
     }
 
     /// Sends a notification if a waker is registered.


### PR DESCRIPTION
Hello, I'm an embedded developer and found this crate. It looks really great, and together with #1 can (almost) let us use this crate without `unsafe` and not fear heap fragmentation, that is a major factor for embedded development. Allocations are accessing global mutable state and can be challenging during engineering of reliable software, as it is another moving part to think about that might cause OOM.

Pattern used in this PR is not new, you can see it in [`rust-embedded/heapless` `spcc::Queue` implementation](https://docs.rs/heapless/latest/heapless/spsc/struct.Queue.html). It can prove that this pattern is already used and praised in embedded ecosystem and your crate will benefit from it too.