### PR TITLE
fix: `WakeSourceRef` having too restrictive lifetime

### DIFF
--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -33,10 +33,10 @@ impl WakeSourceRef<'_> {
     }
 }
 
-impl WakeSinkRef<'_> {
+impl<'a> WakeSinkRef<'a> {
     /// Creates a new source.
     #[inline]
-    pub fn source(&self) -> WakeSourceRef {
+    pub fn source(&self) -> WakeSourceRef<'a> {
         WakeSourceRef { inner: self.inner }
     }
 


### PR DESCRIPTION
Hello, there was a small mistake that removed access to `WakeSinkRef` while there exist some `WakeSourceRef` produced by `WakeSinkRef::source` 