### PR TITLE
upgrade loom version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ alloc = []
 
 [target.'cfg(diatomic_waker_loom)'.dependencies]
 waker-fn = "1.1"
-loom = "0.5"
+loom = "0.7"
 
 [dev-dependencies]
 pollster = "0.3"


### PR DESCRIPTION
I had a transitive issue with dependencies. As this crate depends on `loom`, I need to upgrade `loom` version to consume latest version of the dependencies :)