### PR TITLE
using loom only on tests; features additive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test (Loom)
-        run: cargo test --lib --release
+        run: cargo test --lib --release --all-features
         env:
-          RUSTFLAGS: --cfg diatomic_waker_loom
           LOOM_MAX_PREEMPTIONS: 2
 
   lints:

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -15,6 +15,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test (Loom)
-        run: cargo test --lib --release
-        env:
-          RUSTFLAGS: --cfg diatomic_waker_loom
+        run: cargo test --lib --release --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,12 @@ keywords = ["async", "waker", "atomic", "no_std", "no_alloc"]
 [features]
 default = ["alloc"]
 alloc = []
-
-[target.'cfg(diatomic_waker_loom)'.dependencies]
-waker-fn = "1.1"
-loom = "0.7"
+unittest-with-loom = []
 
 [dev-dependencies]
+waker-fn = "1.1"
+loom = "0.7"
 pollster = "0.3"
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(diatomic_waker_loom)'] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ keywords = ["async", "waker", "atomic", "no_std", "no_alloc"]
 [features]
 default = ["alloc"]
 alloc = []
-unittest-with-loom = []
+loom-tests = []
 
 [dev-dependencies]
 waker-fn = "1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,6 @@
 #![warn(missing_docs, missing_debug_implementations, unreachable_pub)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide))]
-#![cfg_attr(docsrs, doc(cfg_hide(diatomic_waker_loom)))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -175,7 +174,7 @@ pub use borrowed_waker::{WakeSinkRef, WakeSourceRef};
 pub use waker::{DiatomicWaker, WaitUntil};
 
 /// Tests.
-#[cfg(all(test, not(diatomic_waker_loom)))]
+#[cfg(all(test, not(feature = "unittest-with-loom")))]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread;
@@ -247,7 +246,7 @@ mod tests {
 }
 
 /// Loom tests.
-#[cfg(all(test, diatomic_waker_loom))]
+#[cfg(all(test, feature = "unittest-with-loom"))]
 mod tests {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ pub use borrowed_waker::{WakeSinkRef, WakeSourceRef};
 pub use waker::{DiatomicWaker, WaitUntil};
 
 /// Tests.
-#[cfg(all(test, not(feature = "unittest-with-loom")))]
+#[cfg(all(test, not(feature = "loom-tests")))]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread;
@@ -246,7 +246,7 @@ mod tests {
 }
 
 /// Loom tests.
-#[cfg(all(test, feature = "unittest-with-loom"))]
+#[cfg(all(test, feature = "loom-tests"))]
 mod tests {
     use super::*;
 

--- a/src/loom_exports.rs
+++ b/src/loom_exports.rs
@@ -1,23 +1,18 @@
-#[cfg(diatomic_waker_loom)]
-#[allow(unused_imports)]
+
 pub(crate) mod sync {
     pub(crate) mod atomic {
+        #[cfg(all(test, feature = "unittest-with-loom"))]
         pub(crate) use loom::sync::atomic::AtomicUsize;
-    }
-}
-#[cfg(not(diatomic_waker_loom))]
-#[allow(unused_imports)]
-pub(crate) mod sync {
-    pub(crate) mod atomic {
+        #[cfg(not(all(test, feature = "unittest-with-loom")))]
         pub(crate) use core::sync::atomic::AtomicUsize;
     }
 }
 
-#[cfg(diatomic_waker_loom)]
+#[cfg(all(test, feature = "unittest-with-loom"))]
 pub(crate) mod cell {
     pub(crate) use loom::cell::UnsafeCell;
 }
-#[cfg(not(diatomic_waker_loom))]
+#[cfg(not(all(test, feature = "unittest-with-loom")))]
 pub(crate) mod cell {
     #[derive(Debug)]
     pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);

--- a/src/loom_exports.rs
+++ b/src/loom_exports.rs
@@ -1,17 +1,17 @@
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        #[cfg(not(all(test, feature = "unittest-with-loom")))]
+        #[cfg(not(all(test, feature = "loom-tests")))]
         pub(crate) use core::sync::atomic::AtomicUsize;
-        #[cfg(all(test, feature = "unittest-with-loom"))]
+        #[cfg(all(test, feature = "loom-tests"))]
         pub(crate) use loom::sync::atomic::AtomicUsize;
     }
 }
 
-#[cfg(all(test, feature = "unittest-with-loom"))]
+#[cfg(all(test, feature = "loom-tests"))]
 pub(crate) mod cell {
     pub(crate) use loom::cell::UnsafeCell;
 }
-#[cfg(not(all(test, feature = "unittest-with-loom")))]
+#[cfg(not(all(test, feature = "loom-tests")))]
 pub(crate) mod cell {
     #[derive(Debug)]
     pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);

--- a/src/loom_exports.rs
+++ b/src/loom_exports.rs
@@ -1,10 +1,9 @@
-
 pub(crate) mod sync {
     pub(crate) mod atomic {
-        #[cfg(all(test, feature = "unittest-with-loom"))]
-        pub(crate) use loom::sync::atomic::AtomicUsize;
         #[cfg(not(all(test, feature = "unittest-with-loom")))]
         pub(crate) use core::sync::atomic::AtomicUsize;
+        #[cfg(all(test, feature = "unittest-with-loom"))]
+        pub(crate) use loom::sync::atomic::AtomicUsize;
     }
 }
 

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -68,7 +68,7 @@ pub struct DiatomicWaker {
 
 impl DiatomicWaker {
     /// Creates a new `DiatomicWaker`.
-    #[cfg(not(diatomic_waker_loom))]
+    #[cfg(not(all(test, feature = "unittest-with-loom")))]
     pub const fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),
@@ -76,7 +76,7 @@ impl DiatomicWaker {
         }
     }
 
-    #[cfg(diatomic_waker_loom)]
+    #[cfg(all(test, feature = "unittest-with-loom"))]
     pub fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -68,7 +68,7 @@ pub struct DiatomicWaker {
 
 impl DiatomicWaker {
     /// Creates a new `DiatomicWaker`.
-    #[cfg(not(all(test, feature = "unittest-with-loom")))]
+    #[cfg(not(all(test, feature = "loom-tests")))]
     pub const fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),
@@ -76,7 +76,7 @@ impl DiatomicWaker {
         }
     }
 
-    #[cfg(all(test, feature = "unittest-with-loom"))]
+    #[cfg(all(test, feature = "loom-tests"))]
     pub fn new() -> Self {
         Self {
             state: AtomicUsize::new(0),


### PR DESCRIPTION
**Work done**
- Configuring `loom` as a `dev-dependency`.
- Creating a `loom-tests` feature that is no-op, except for `diatomic-waker` unit tests.

**Benefits**
- Removing `loom` as dependency of `diatomic-waker`.
- After upgrade of `loom` from `0.5` to `0.7`, MSRV should go up because of the `loom` dependency. Now this is not required anymore, except for testing scenarios.
- Loom does not appear in production code at all :).

