### PR TITLE
Remove `Unpin` bound in `wait_until` and clean up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
-  RUSTDOCFLAGS: -Dwarnings
 
 jobs:
   check:
@@ -57,7 +56,7 @@ jobs:
       - name: Run cargo test (Loom)
         run: cargo test --lib --release --all-features
         env:
-          RUSTFLAGS: --cfg diatomic_waker_loom
+          RUSTFLAGS: --cfg diatomic_waker_loom -Dwarnings
           LOOM_MAX_PREEMPTIONS: 2
 
   lints:
@@ -91,4 +90,4 @@ jobs:
       - name: Run cargo doc
         run: cargo +nightly doc --no-deps --document-private-items --all-features
         env:
-            RUSTDOCFLAGS: --cfg docsrs
+            RUSTDOCFLAGS: --cfg docsrs -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Run cargo doc
-        run: RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --document-private-items --all-features
+        run: cargo +nightly doc --no-deps --document-private-items --all-features
+        env:
+            RUSTDOCFLAGS: --cfg docsrs

--- a/src/arc_waker.rs
+++ b/src/arc_waker.rs
@@ -66,7 +66,7 @@ impl WakeSink {
     #[inline]
     pub fn wait_until<P, T>(&mut self, predicate: P) -> WaitUntil<'_, P, T>
     where
-        P: FnMut() -> Option<T> + Unpin,
+        P: FnMut() -> Option<T>,
     {
         // Safety: `DiatomicWaker::register`, `DiatomicWaker::unregister` and
         // `DiatomicWaker::wait_until` cannot be used concurrently from multiple

--- a/src/arc_waker.rs
+++ b/src/arc_waker.rs
@@ -5,7 +5,7 @@ use crate::DiatomicWaker;
 use crate::WaitUntil;
 
 /// An owned object that can await notifications from one or several
-/// [`WakeSource`](WakeSource)s.
+/// [`WakeSource`]s.
 ///
 /// See the [crate-level documentation](crate) for usage.
 #[derive(Debug, Default)]
@@ -76,7 +76,7 @@ impl WakeSink {
     }
 }
 
-/// An owned object that can send notifications to a [`WakeSink`](WakeSink).
+/// An owned object that can send notifications to a [`WakeSink`].
 ///
 /// See the [crate-level documentation](crate) for usage.
 #[derive(Clone, Debug)]

--- a/src/borrowed_waker.rs
+++ b/src/borrowed_waker.rs
@@ -58,7 +58,7 @@ impl<'a> WakeSinkRef<'a> {
     #[inline]
     pub fn wait_until<P, T>(&mut self, predicate: P) -> WaitUntil<'_, P, T>
     where
-        P: FnMut() -> Option<T> + Unpin,
+        P: FnMut() -> Option<T>,
     {
         // Safety: `DiatomicWaker::register`, `DiatomicWaker::unregister` and
         // `DiatomicWaker::wait_until` cannot be used concurrently from multiple

--- a/src/borrowed_waker.rs
+++ b/src/borrowed_waker.rs
@@ -3,7 +3,7 @@ use core::task::Waker;
 use crate::{DiatomicWaker, WaitUntil};
 
 /// A non-owned object that can await notifications from one or several
-/// [`WakeSourceRef`](WakeSourceRef)s.
+/// [`WakeSourceRef`]s.
 ///
 /// See the [crate-level documentation](crate) for usage.
 #[derive(Debug)]
@@ -69,8 +69,7 @@ impl<'a> WakeSinkRef<'a> {
     }
 }
 
-/// A non-owned object that can send notifications to a
-/// [`WakeSinkRef`](WakeSinkRef).
+/// A non-owned object that can send notifications to a [`WakeSinkRef`].
 ///
 /// See the [crate-level documentation](crate) for usage.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Hello, currently `arc_waker` and `borrowed_waker` do require predicate `P` to be unpin, so unconditionally implementing `Unpin` for `WaitUntil` is sound for those cases. `DiatomicWaker::wait_until` is no longer requiring `P` to be `Unpin`, and while it is `unsafe` function, it is not mentioning in it's documentation that `P` must be `Unpin`, so this is theoretically unsound (I guess will not happen in practice, as who would have !Unpin predicate?).

I assume it is some leftover after https://github.com/asynchronics/diatomic-waker/commit/4a208d2f8725a6d3b0343aa805e22c24c3bb82ba, this PR is continuing that commit, as safe versions did still required `Unpin`. Now `Unpin` is automatically implemented for `WaitUntil`, and if `P` would be `!Unpin`, `WaitUntil` would be too.