### PR TITLE
Add an implementation backed by 128-bit atomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 env:
-  RUSTFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings -Ctarget-feature=+cmpxchg16b
 
 jobs:
   check:
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.56.1
+          - 1.84.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -28,7 +28,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --no-default-features
+
+      - name: Run cargo check --all-features
+        run: cargo check --all-features
 
   test:
     name: Test suite
@@ -40,7 +43,10 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run cargo test
+      - name: Run cargo test --features alloc
+        run: cargo test --no-default-features --features alloc
+
+      - name: Run cargo test --all-features
         run: cargo test --all-features
 
   loom-light:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+- Support using 128-bit atomics on platforms that support it. ([#17])
+- Bump MSRV to 1.84 ([#17])
+
+[#17]: https://github.com/asynchronics/diatomic-waker/pull/17
+
+
 # 0.2.3 (2024-09-08)
 
 - Remove `Unpin` bound on `wait_until` methods ([#15]).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ portable-atomic = { version = "1.11.1", optional = true }
 
 [dev-dependencies]
 pollster = "0.3"
+criterion = "0.6.0"
 
 [target.'cfg(diatomic_waker_loom)'.dev-dependencies]
 waker-fn = "1.1"
@@ -39,3 +40,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(diatomic_waker_loom)'] }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[bench]]
+name = "benches"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "diatomic-waker"
 version = "0.2.3"
 authors = ["Asynchronics and contributors"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.84"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/asynchronics/diatomic-waker"
 readme = "README.md"
@@ -19,8 +19,12 @@ categories = ["asynchronous", "concurrency"]
 keywords = ["async", "waker", "atomic", "no_std", "no_alloc"]
 
 [features]
-default = ["alloc"]
+default = ["alloc", "atomic"]
 alloc = []
+atomic = ["portable-atomic"]
+
+[dependencies]
+portable-atomic = { version = "1.11.1", optional = true }
 
 [dev-dependencies]
 pollster = "0.3"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ By default, this crate enables the `alloc` feature to provide the owned
 `WakeSink` and `WakeSource`. It can be made `no-std`-compatible by specifying
 `default-features = false`.
 
+The default-enabled feature `atomic` uses the [`portable-atomic`] crate
+to switch to an optimized implementation based on 128-bit atomics on supported
+platforms (e.g. x86\_64 with cmpxchg16b, all aarch64, or riscv64 with zacas).
+
+[`portable-atomic`]: https://docs.rs/portable-atomic
+
+
 ## Example
 
 A multi-producer, single-consumer channel of capacity 1 for sending

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,0 +1,34 @@
+use std::{sync::Arc, task::{Wake, Waker}};
+
+use criterion::Criterion;
+
+use diatomic_waker::DiatomicWaker;
+
+fn main() {
+    let mut c = Criterion::default().configure_from_args();
+
+    let waker = Waker::from(Arc::new(ExampleWaker(0)));
+
+    c.bench_function("register_same", |b| {
+        let mut slot = DiatomicWaker::new();
+        slot.sink_ref().register(&waker);
+        b.iter(|| slot.sink_ref().register(&waker));
+    });
+
+    c.bench_function("register_same_wake", |b| {
+        let mut slot = DiatomicWaker::new();
+        slot.sink_ref().register(&waker);
+        b.iter(|| {
+            slot.sink_ref().register(&waker);
+            slot.notify();
+        });
+    });
+}
+
+/// A simple waker whose clone operation is not just a no-op.
+struct ExampleWaker(#[expect(dead_code)] u8);
+
+impl Wake for ExampleWaker {
+    fn wake(self: Arc<Self>) {}
+    fn wake_by_ref(self: &Arc<Self>) {}
+}

--- a/src/impl_atomic.rs
+++ b/src/impl_atomic.rs
@@ -28,6 +28,13 @@ impl DiatomicWaker {
     }
 
     pub(crate) fn notify(&self) {
+        // Implement a fast path to avoid dropping the waker if it's inactive. This can avoid
+        // cloning wakers later on.
+        // Ordering: We don't have any data dependencies here, so `Relaxed` is sufficient.
+        if self.inner.load(Ordering::Relaxed) & 1 != 0 {
+            return;
+        }
+
         // Ordering:
         // - Acquire is necessary since we access the `Waker`'s methods after this, thus need to
         //   acquire the current shared state of the waker.

--- a/src/impl_atomic.rs
+++ b/src/impl_atomic.rs
@@ -18,6 +18,7 @@ pub(crate) const ENABLE: bool =
     AtomicTwoUsize::is_always_lock_free() && cfg!(not(all(test, diatomic_waker_loom)));
 
 impl DiatomicWaker {
+    #[cfg(not(all(test, diatomic_waker_loom)))]
     pub(crate) const fn new() -> [Self; ENABLE as usize] {
         [const {
             Self {

--- a/src/impl_atomic.rs
+++ b/src/impl_atomic.rs
@@ -1,0 +1,138 @@
+use core::mem::ManuallyDrop;
+use core::ptr;
+use core::sync::atomic::Ordering;
+use core::task::RawWaker;
+use core::task::RawWakerVTable;
+use core::task::Waker;
+
+#[derive(Debug)]
+pub(crate) struct DiatomicWaker {
+    // The lowest bit (which we can use since `RawWakerVTable` will have an alignment of at least
+    // two) stores whether the waker is "inactive"; if set, wakes on the slot should be ignored
+    // (but the slot still holds an owned waker).
+    inner: AtomicTwoUsize,
+}
+
+// Loom has no 128-bit atomics, so we disable the implementation there.
+pub(crate) const ENABLE: bool =
+    AtomicTwoUsize::is_always_lock_free() && cfg!(not(all(test, diatomic_waker_loom)));
+
+impl DiatomicWaker {
+    pub(crate) const fn new() -> [Self; ENABLE as usize] {
+        [const {
+            Self {
+                inner: AtomicTwoUsize::new(0),
+            }
+        }; ENABLE as usize]
+    }
+
+    pub(crate) fn notify(&self) {
+        // Ordering:
+        // - Acquire is necessary since we access the `Waker`'s methods after this, thus need to
+        //   acquire the current shared state of the waker.
+        // - Release is not necessary, since we're just storing a constant (zero) without dependent
+        //   data.
+        let waker = self.inner.swap(0, Ordering::Acquire);
+
+        // Wake the waker if there is an active one.
+        if let Some((waker, false)) = unsafe { decode_waker(waker) } {
+            waker.wake();
+        }
+    }
+
+    pub(crate) fn register(&self, waker: &Waker) {
+        // Implement a fast path that avoids cloning the waker.
+        // Ordering: Acquire is unnecessary, since we don't do anything with the `Waker` that we
+        // load.
+        let initial = self.inner.load(Ordering::Relaxed);
+        if initial & (!1) == encode_waker(waker) {
+            // If the waker was active, we're good. If the waker was inactive, we try to make it
+            // active; if this fails, then a concurrent call to `notify` has dropped the stored
+            // clone of the waker, so we should clone our waker in as usual.
+            // Ordering:
+            // - Acquire is unnecessary, since if the value changed, it must have changed to zero,
+            //   and in this case there is nothing to acquire.
+            // - On sucess, Release ensures that any calls to `wake` happen-after this function
+            //   call. This shouldn't be necessary for soundness, but is probably useful for
+            //   sanity.
+            if initial & 1 == 0
+                || self
+                    .inner
+                    .compare_exchange(
+                        initial,
+                        initial & (!1),
+                        Ordering::Release,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+            {
+                return;
+            }
+        }
+
+        // Clone and swap in our new waker, then the drop the old one.
+        let waker = encode_waker(&ManuallyDrop::new(waker.clone()));
+
+        // Ordering:
+        // - Acquire is necessary, since we drop the old waker, and thus need to acquire its current
+        //   shared state.
+        // - Release is necessary, as other threads need to be able to acquire the state changes
+        //   produced by the above `.clone()`.
+        let old_waker = self.inner.swap(waker, Ordering::AcqRel);
+        drop(unsafe { decode_waker(old_waker) });
+    }
+
+    pub(crate) fn unregister(&self) {
+        // Just set the inactive bit. If there is no waker that's also okay.
+        self.inner.fetch_or(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+type TwoUsize = u64;
+
+#[cfg(target_pointer_width = "32")]
+type AtomicTwoUsize = portable_atomic::AtomicU64;
+
+#[cfg(target_pointer_width = "64")]
+type TwoUsize = u128;
+
+#[cfg(target_pointer_width = "64")]
+type AtomicTwoUsize = portable_atomic::AtomicU128;
+
+/// "Encode" a `Waker` into its two-usize-based representation. The waker will be active.
+fn encode_waker(waker: &Waker) -> TwoUsize {
+    // Needed since we use the least significant bit to store the "active" state.
+    const { assert!(2 <= align_of::<RawWakerVTable>()) };
+
+    let data = waker.data().expose_provenance();
+    let vtable = ptr::from_ref(waker.vtable()).expose_provenance();
+
+    (data as TwoUsize) << usize::BITS | (vtable as TwoUsize)
+}
+
+/// "Decode" a `Waker` from its two-usize-based representation, or `None` if the given value was
+/// zero. Returns a (waker, inactive) tuple.
+///
+/// # Safety
+///
+/// The value (excluding its last bit) must have previously been obtained from `encode_waker`, or be
+/// zero.
+unsafe fn decode_waker(val: TwoUsize) -> Option<(Waker, bool)> {
+    let inactive = val & 1 != 0;
+    let val = val & (!1);
+
+    if val == 0 {
+        return None;
+    }
+
+    let data = ptr::with_exposed_provenance::<()>((val >> usize::BITS) as usize);
+
+    // Safety: Ensured by the caller
+    let vtable = unsafe { &*ptr::with_exposed_provenance::<RawWakerVTable>(val as usize) };
+
+    let raw_waker = RawWaker::new(data, vtable);
+
+    // Safety: Ensured by the caller
+    Some((unsafe { Waker::from_raw(raw_waker) }, inactive))
+}

--- a/src/impl_lockfree.rs
+++ b/src/impl_lockfree.rs
@@ -1,0 +1,418 @@
+use core::sync::atomic::Ordering;
+use core::task::Waker;
+
+use crate::loom_exports::cell::UnsafeCell;
+use crate::loom_exports::sync::atomic::AtomicUsize;
+
+// The state of the waker is tracked by the following bit flags:
+//
+// * INDEX [I]: slot index of the current waker, if any (0 or 1),
+// * UPDATE [U]: an updated waker has been registered in the redundant slot at
+//   index 1 - INDEX,
+// * REGISTERED [R]: a waker is registered and awaits a notification
+// * LOCKED [L]: a notifier has taken the notifier lock and is in the process of
+//   sending a notification,
+// * NOTIFICATION [N]: a notifier has failed to take the lock when a waker was
+//   registered and has requested the notifier holding the lock to send a
+//   notification on its behalf (implies REGISTERED and LOCKED).
+//
+// The waker stored in the slot at INDEX ("current" waker) is shared between the
+// sink (entity which registers wakers) and the source that holds the notifier
+// lock (if any). For this reason, this waker may only be accessed by shared
+// reference. The waker at 1 - INDEX is exclusively owned by the sink, which is
+// free to mutate it.
+
+// Summary of valid states:
+//
+// |  N   L   R   U   I  |
+// |---------------------|
+// |  0  any any any any |
+// |  1   1   1  any any |
+
+// [I] Index of the current waker (0 or 1).
+const INDEX: usize = 0b00001;
+// [U] Indicates that an updated waker is available at 1 - INDEX.
+const UPDATE: usize = 0b00010;
+// [R] Indicates that a waker has been registered.
+const REGISTERED: usize = 0b00100;
+// [L] Indicates that a notifier holds the notifier lock to the waker at INDEX.
+const LOCKED: usize = 0b01000;
+// [N] Indicates that a notifier has failed to acquire the lock and has
+// requested the notifier holding the lock to notify on its behalf.
+const NOTIFICATION: usize = 0b10000;
+
+#[derive(Debug)]
+pub(crate) struct DiatomicWaker {
+    /// A bit field for `INDEX`, `UPDATE`, `REGISTERED`, `LOCKED` and `NOTIFICATION`.
+    state: AtomicUsize,
+    /// Redundant slots for the waker.
+    waker: [UnsafeCell<Option<Waker>>; 2],
+}
+
+impl DiatomicWaker {
+    #[cfg(not(all(test, diatomic_waker_loom)))]
+    pub(crate) const fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+            waker: [UnsafeCell::new(None), UnsafeCell::new(None)],
+        }
+    }
+
+    #[cfg(all(test, diatomic_waker_loom))]
+    pub(crate) fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+            waker: [UnsafeCell::new(None), UnsafeCell::new(None)],
+        }
+    }
+
+    pub(crate) fn notify(&self) {
+        // Transitions: see `try_lock` and `try_unlock`.
+
+        let mut state = if let Ok(s) = try_lock(&self.state) {
+            s
+        } else {
+            return;
+        };
+
+        loop {
+            let idx = state & INDEX;
+
+            // Safety: the notifier lock has been acquired, which guarantees
+            // exclusive access to the waker at `INDEX`.
+            unsafe {
+                self.wake_by_ref(idx);
+            }
+
+            if let Err(s) = try_unlock(&self.state, state) {
+                state = s;
+            } else {
+                return;
+            }
+
+            // One more loop iteration is necessary because the waker was
+            // registered again and another notifier has failed to send a
+            // notification while the notifier lock was taken.
+        }
+    }
+
+    pub(crate) unsafe fn register(&self, waker: &Waker) {
+        // Transitions if the new waker is the same as the one currently stored.
+        //
+        // |  N  L  R  U  I  |  N  L  R  U  I  |
+        // |-----------------|-----------------|
+        // |  n  l  r  u  i  |  n  l  1  u  i  |
+        //
+        //
+        // Transitions if the new waker needs to be stored:
+        //
+        // Step 1 (only necessary if the state initially indicates R=U=1):
+        //
+        // |  N  L  R  U  I  |  N  L  R  U  I  |
+        // |-----------------|-----------------|
+        // |  n  l  r  u  i  |  0  l  0  u  i  |
+        //
+        // Step 2:
+        //
+        // |  N  L  R  U  I  |  N  L  R  U  I  |
+        // |-----------------|-----------------|
+        // |  n  l  r  u  i  |  n  l  1  1  i  |
+
+        // Ordering: Acquire ordering is necessary to synchronize with the
+        // Release unlocking operation in `notify`, which ensures that all calls
+        // to the waker in the redundant slot have completed.
+        let state = self.state.load(Ordering::Acquire);
+
+        // Compute the index of the waker that was most recently updated. Note
+        // that the value of `recent_idx` as computed below remains correct even
+        // if the state is stale since only this thread can store new wakers.
+        let mut idx = state & INDEX;
+        let recent_idx = if state & UPDATE == 0 {
+            idx
+        } else {
+            INDEX - idx
+        };
+
+        // Safety: it is safe to call `will_wake` since the registering thread
+        // is the only one allowed to mutate the wakers so there can be no
+        // concurrent mutable access to the waker.
+        let is_up_to_date = self.will_wake(recent_idx, waker);
+
+        // Fast path in case the waker is up to date.
+        if is_up_to_date {
+            // Set the `REGISTERED` flag. Ideally, the `NOTIFICATION` flag would
+            // be cleared at the same time to avoid a spurious wake-up, but it
+            // probably isn't worth the overhead of a CAS loop because having
+            // this flag set when calling `register` is very unlikely: it would
+            // mean that since the last call to `register`:
+            // 1) a notifier has been holding the lock continuously,
+            // 2) another notifier has tried and failed to take the lock, and
+            // 3) `unregister` was never called.
+            //
+            // Ordering: Acquire ordering synchronizes with the Release and
+            // AcqRel RMWs in `try_lock` (called by `notify`) and ensures that
+            // either the predicate set before the call to `notify` will be
+            // visible after the call to `register`, or the registered waker
+            // will be visible during the call to `notify` (or both). Note that
+            // Release ordering is not necessary since the waker has not changed
+            // and this RMW takes part in a release sequence headed by the
+            // initial registration of the waker.
+            self.state.fetch_or(REGISTERED, Ordering::Acquire);
+
+            return;
+        }
+
+        // The waker needs to be stored in the redundant slot.
+        //
+        // It is necessary to make sure that either the `UPDATE` or the
+        // `REGISTERED` flag is cleared to prevent concurrent access by a notifier
+        // to the redundant waker slot while the waker is updated.
+        //
+        // Note that only the thread registering the waker can set `REGISTERED`
+        // and `UPDATE` so even if the state is stale, observing `REGISTERED` or
+        // `UPDATE` as cleared guarantees that such flag is and will remain
+        // cleared until this thread sets them.
+        if state & (UPDATE | REGISTERED) == (UPDATE | REGISTERED) {
+            // Clear the `REGISTERED` and `NOTIFICATION` flags.
+            //
+            // Ordering: Acquire ordering is necessary to synchronize with the
+            // Release unlocking operation in `notify`, which ensures that all
+            // calls to the waker in the redundant slot have completed.
+            let state = self
+                .state
+                .fetch_and(!(REGISTERED | NOTIFICATION), Ordering::Acquire);
+
+            // It is possible that `UPDATE` was cleared and `INDEX` was switched
+            // by a notifier after the initial load of the state, so the waker
+            // index needs to be updated.
+            idx = state & INDEX;
+        }
+
+        // Always store the new waker in the redundant slot to avoid racing with
+        // a notifier.
+        let redundant_idx = 1 - idx;
+
+        // Store the new waker.
+        //
+        // Safety: it is safe to store the new waker in the redundant slot
+        // because the `REGISTERED` flag and/or the `UPDATE` flag are/is cleared
+        // so the notifier will not attempt to switch the waker.
+        self.set_waker(redundant_idx, waker.clone());
+
+        // Make the waker visible.
+        //
+        // Ordering: Acquire ordering synchronizes with the Release and AcqRel
+        // RMWs in `try_lock` (called by `notify`) and ensures that either the
+        // predicate set before the call to `notify` will be visible after the
+        // call to `register`, or the registered waker will be visible during
+        // the call to `notify` (or both). Since the waker has been modified
+        // above, Release ordering is also necessary to synchronize with the
+        // AcqRel RMW in `try_lock` (success case) and ensure that the
+        // modification to the waker is fully visible when notifying.
+        self.state.fetch_or(UPDATE | REGISTERED, Ordering::AcqRel);
+    }
+
+    pub(crate) unsafe fn unregister(&self) {
+        // Transitions:
+        //
+        // |  N  L  R  U  I  |  N  L  R  U  I  |
+        // |-----------------|-----------------|
+        // |  n  l  r  u  i  |  0  l  0  u  i  |
+
+        // Modify the state. Note that the waker is not dropped: caching it can
+        // avoid a waker drop/cloning cycle (typically, 2 RMWs) in the frequent
+        // case when the next waker to be registered will be the same as the one
+        // being unregistered.
+        //
+        // Ordering: no waker was modified so Relaxed ordering is sufficient.
+        self.state
+            .fetch_and(!(REGISTERED | NOTIFICATION), Ordering::Relaxed);
+    }
+
+    /// Sets the waker at index `idx`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have exclusive access to the waker at index `idx`.
+    unsafe fn set_waker(&self, idx: usize, new: Waker) {
+        self.waker[idx].with_mut(|waker| (*waker) = Some(new));
+    }
+
+    /// Notify the waker at index `idx`.
+    ///
+    /// # Safety
+    ///
+    /// The waker at index `idx` cannot be modified concurrently.
+    unsafe fn wake_by_ref(&self, idx: usize) {
+        self.waker[idx].with(|waker| {
+            if let Some(waker) = &*waker {
+                waker.wake_by_ref();
+            }
+        });
+    }
+
+    /// Check whether the waker at index `idx` will wake the same task as the
+    /// provided waker.
+    ///
+    /// # Safety
+    ///
+    /// The waker at index `idx` cannot be modified concurrently.
+    unsafe fn will_wake(&self, idx: usize, other: &Waker) -> bool {
+        self.waker[idx].with(|waker| match &*waker {
+            Some(waker) => waker.will_wake(other),
+            None => false,
+        })
+    }
+}
+
+unsafe impl Send for DiatomicWaker {}
+unsafe impl Sync for DiatomicWaker {}
+
+/// Attempts to acquire the notifier lock and returns the current state upon
+/// success.
+///
+/// Acquisition of the lock will fail in the following cases:
+///
+/// * the `REGISTERED` flag is cleared, meaning that there is no need to wake
+///   and therefore no need to lock,
+/// * the lock is already taken, in which case the `NOTIFICATION` flag will be
+///   set if the `REGISTERED` flag is set.
+///
+/// If acquisition of the lock succeeds, the `REGISTERED` flag is cleared. If
+/// additionally the `UPDATE` flag was set, it is cleared and `INDEX` is
+/// flipped.
+///
+///  Transition table:
+///
+/// |  N  L  R  U  I  |  N  L  R  U  I  |
+/// |-----------------|-----------------|
+/// |  0  0  0  u  i  |  0  0  0  u  i  | (failure)
+/// |  0  0  1  0  i  |  0  1  0  0  i  | (success)
+/// |  0  0  1  1  i  |  0  1  0  0 !i  | (success)
+/// |  0  1  0  u  i  |  0  1  0  u  i  | (failure)
+/// |  n  1  1  u  i  |  1  1  1  u  i  | (failure)
+///
+fn try_lock(state: &AtomicUsize) -> Result<usize, ()> {
+    let mut old_state = state.load(Ordering::Relaxed);
+
+    loop {
+        if old_state & (LOCKED | REGISTERED) == REGISTERED {
+            // Success path.
+
+            // If `UPDATE` is set, clear `UPDATE` and flip `INDEX` with the xor
+            // mask.
+            let update_bit = old_state & UPDATE;
+            let xor_mask = update_bit | (update_bit >> 1);
+
+            // Set `LOCKED` and clear `REGISTERED` with the xor mask.
+            let xor_mask = xor_mask | LOCKED | REGISTERED;
+
+            let new_state = old_state ^ xor_mask;
+
+            // Ordering: Acquire is necessary to synchronize with the Release
+            // ordering in `register` so that the new waker, if any, is visible.
+            // Release ordering synchronizes with the Acquire and AcqRel RMWs in
+            // `register` and ensures that either the predicate set before the
+            // call to `notify` will be visible after the call to `register`, or
+            // the registered waker will be visible during the call to `notify`
+            // (or both).
+            match state.compare_exchange_weak(
+                old_state,
+                new_state,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(new_state),
+                Err(s) => old_state = s,
+            }
+        } else {
+            // Failure path.
+
+            // Set the `NOTIFICATION` bit if `REGISTERED` was set.
+            let registered_bit = old_state & REGISTERED;
+            let new_state = old_state | (registered_bit << 2);
+
+            // Ordering: Release ordering synchronizes with the Acquire and
+            // AcqRel RMWs in `register` and ensures that either the predicate
+            // set before the call to `notify` will be visible after the call to
+            // `register`, or the registered waker will be visible during the
+            // call to `notify` (or both).
+            match state.compare_exchange_weak(
+                old_state,
+                new_state,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Err(()),
+                Err(s) => old_state = s,
+            }
+        };
+    }
+}
+
+/// Attempts to release the notifier lock and returns the current state upon
+/// failure.
+///
+/// Release of the lock will fail if the `NOTIFICATION` flag is set because it
+/// means that, after the lock was taken, the registering thread has requested
+/// to be notified again and another notifier has subsequently requested that
+/// such notification be sent on its behalf; if additionally the `UPDATE` flag
+/// was set (i.e. a new waker is available), it is cleared and `INDEX` is
+/// flipped.
+///
+/// Transition table:
+///
+/// |  N  L  R  U  I  |  N  L  R  U  I  |
+/// |-----------------|-----------------|
+/// |  0  1  r  u  i  |  0  0  r  u  i  | (success)
+/// |  1  1  1  0  i  |  0  1  0  0  i  | (failure)
+/// |  1  1  1  1  i  |  0  1  0  0 !i  | (failure)
+///
+fn try_unlock(state: &AtomicUsize, mut old_state: usize) -> Result<(), usize> {
+    loop {
+        if old_state & NOTIFICATION == 0 {
+            // Success path.
+
+            let new_state = old_state & !LOCKED;
+
+            // Ordering: Release is necessary to synchronize with the Acquire
+            // ordering in `register` and ensure that the waker call has
+            // completed before a new waker is stored.
+            match state.compare_exchange_weak(
+                old_state,
+                new_state,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(s) => old_state = s,
+            }
+        } else {
+            // Failure path.
+
+            // If `UPDATE` is set, clear `UPDATE` and flip `INDEX` with the xor mask.
+            let update_bit = old_state & UPDATE;
+            let xor_mask = update_bit | (update_bit >> 1);
+
+            // Clear `NOTIFICATION` and `REGISTERED` with the xor mask.
+            let xor_mask = xor_mask | NOTIFICATION | REGISTERED;
+
+            let new_state = old_state ^ xor_mask;
+
+            // Ordering: Release is necessary to synchronize with the Acquire
+            // ordering in `register` and ensure that the call to
+            // `Waker::wake_by_ref` has completed before a new waker is stored.
+            // Acquire ordering is in turn necessary to ensure that any newly
+            // registered waker is visible.
+            match state.compare_exchange_weak(
+                old_state,
+                new_state,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Err(new_state),
+                Err(s) => old_state = s,
+            }
+        };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,11 @@
 //! [`WakeSink`] and [`WakeSource`]. It can be made `no-std`-compatible by
 //! specifying `default-features = false`.
 //!
+//! The default-enabled feature `atomic` uses the [`portable-atomic`] crate
+//! to switch to an optimized implementation based on 128-bit atomics on supported
+//! platforms (e.g. x86\_64 with cmpxchg16b, all aarch64, or riscv64 with zacas).
+//!
+//![`portable-atomic`]: https://docs.rs/portable-atomic
 //!
 //! # Examples
 //!
@@ -160,7 +165,6 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 mod arc_waker;
 mod borrowed_waker;
-mod loom_exports;
 #[deprecated(
     since = "0.2.0",
     note = "items from this module are now available in the root module"
@@ -172,6 +176,64 @@ mod waker;
 pub use arc_waker::{WakeSink, WakeSource};
 pub use borrowed_waker::{WakeSinkRef, WakeSourceRef};
 pub use waker::{DiatomicWaker, WaitUntil};
+
+mod impl_lockfree;
+
+cfg_has_required_atomics! {
+    mod impl_atomic;
+}
+
+cfg_no_required_atomics! {
+    mod impl_atomic {
+        #[derive(Debug)]
+        pub(crate) enum DiatomicWaker {}
+
+        impl DiatomicWaker {
+            pub(crate) const fn new() -> [Self; ENABLE as usize] {
+                []
+            }
+            pub(crate) fn notify(&self) {
+                match *self {}
+            }
+            pub(crate) fn register(&self, _: &core::task::Waker) {
+                match *self {}
+            }
+            pub(crate) fn unregister(&self) {
+                match *self {}
+            }
+        }
+
+        pub(crate) const ENABLE: bool = false;
+    }
+}
+
+#[cfg(all(feature = "atomic", target_pointer_width = "32"))]
+use portable_atomic::cfg_no_atomic_64 as cfg_no_required_atomics;
+
+#[cfg(all(feature = "atomic", target_pointer_width = "32"))]
+use portable_atomic::cfg_has_atomic_64 as cfg_has_required_atomics;
+
+#[cfg(all(feature = "atomic", target_pointer_width = "64"))]
+use portable_atomic::cfg_no_atomic_128 as cfg_no_required_atomics;
+
+#[cfg(all(feature = "atomic", target_pointer_width = "64"))]
+use portable_atomic::cfg_has_atomic_128 as cfg_has_required_atomics;
+
+#[cfg(not(feature = "atomic"))]
+macro_rules! cfg_no_required_atomics {
+    ($($t:tt)*) => { $($t)* };
+}
+#[cfg(not(feature = "atomic"))]
+use cfg_no_required_atomics;
+
+#[cfg(not(feature = "atomic"))]
+macro_rules! cfg_has_required_atomics {
+    ($($t:tt)*) => {};
+}
+#[cfg(not(feature = "atomic"))]
+use cfg_has_required_atomics;
+
+mod loom_exports;
 
 /// Tests.
 #[cfg(all(test, not(diatomic_waker_loom)))]

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -1,48 +1,9 @@
 use core::future::Future;
 use core::pin::Pin;
-use core::sync::atomic::Ordering;
 use core::task::{Context, Poll, Waker};
 
-use crate::loom_exports::cell::UnsafeCell;
-use crate::loom_exports::sync::atomic::AtomicUsize;
 use crate::WakeSinkRef;
-
-// The state of the waker is tracked by the following bit flags:
-//
-// * INDEX [I]: slot index of the current waker, if any (0 or 1),
-// * UPDATE [U]: an updated waker has been registered in the redundant slot at
-//   index 1 - INDEX,
-// * REGISTERED [R]: a waker is registered and awaits a notification
-// * LOCKED [L]: a notifier has taken the notifier lock and is in the process of
-//   sending a notification,
-// * NOTIFICATION [N]: a notifier has failed to take the lock when a waker was
-//   registered and has requested the notifier holding the lock to send a
-//   notification on its behalf (implies REGISTERED and LOCKED).
-//
-// The waker stored in the slot at INDEX ("current" waker) is shared between the
-// sink (entity which registers wakers) and the source that holds the notifier
-// lock (if any). For this reason, this waker may only be accessed by shared
-// reference. The waker at 1 - INDEX is exclusively owned by the sink, which is
-// free to mutate it.
-
-// Summary of valid states:
-//
-// |  N   L   R   U   I  |
-// |---------------------|
-// |  0  any any any any |
-// |  1   1   1  any any |
-
-// [I] Index of the current waker (0 or 1).
-const INDEX: usize = 0b00001;
-// [U] Indicates that an updated waker is available at 1 - INDEX.
-const UPDATE: usize = 0b00010;
-// [R] Indicates that a waker has been registered.
-const REGISTERED: usize = 0b00100;
-// [L] Indicates that a notifier holds the notifier lock to the waker at INDEX.
-const LOCKED: usize = 0b01000;
-// [N] Indicates that a notifier has failed to acquire the lock and has
-// requested the notifier holding the lock to notify on its behalf.
-const NOTIFICATION: usize = 0b10000;
+use crate::{impl_atomic, impl_lockfree};
 
 /// A primitive that can send or await notifications.
 ///
@@ -60,10 +21,8 @@ const NOTIFICATION: usize = 0b10000;
 /// custom synchronization primitives.
 #[derive(Debug)]
 pub struct DiatomicWaker {
-    /// A bit field for `INDEX`, `UPDATE`, `REGISTERED`, `LOCKED` and `NOTIFICATION`.
-    state: AtomicUsize,
-    /// Redundant slots for the waker.
-    waker: [UnsafeCell<Option<Waker>>; 2],
+    atomic: [impl_atomic::DiatomicWaker; impl_atomic::ENABLE as usize],
+    lock_free: [impl_lockfree::DiatomicWaker; (!impl_atomic::ENABLE) as usize],
 }
 
 impl DiatomicWaker {
@@ -71,16 +30,17 @@ impl DiatomicWaker {
     #[cfg(not(all(test, diatomic_waker_loom)))]
     pub const fn new() -> Self {
         Self {
-            state: AtomicUsize::new(0),
-            waker: [UnsafeCell::new(None), UnsafeCell::new(None)],
+            atomic: impl_atomic::DiatomicWaker::new(),
+            lock_free: [const { impl_lockfree::DiatomicWaker::new() };
+                (!impl_atomic::ENABLE) as usize],
         }
     }
 
     #[cfg(all(test, diatomic_waker_loom))]
     pub fn new() -> Self {
         Self {
-            state: AtomicUsize::new(0),
-            waker: [UnsafeCell::new(None), UnsafeCell::new(None)],
+            atomic: [],
+            lock_free: [crate::impl_lockfree::DiatomicWaker::new()],
         }
     }
 
@@ -96,33 +56,12 @@ impl DiatomicWaker {
     ///
     /// This automatically unregisters any waker that may have been previously
     /// registered.
+    #[expect(clippy::out_of_bounds_indexing)]
     pub fn notify(&self) {
-        // Transitions: see `try_lock` and `try_unlock`.
-
-        let mut state = if let Ok(s) = try_lock(&self.state) {
-            s
+        if impl_atomic::ENABLE {
+            self.atomic[0].notify();
         } else {
-            return;
-        };
-
-        loop {
-            let idx = state & INDEX;
-
-            // Safety: the notifier lock has been acquired, which guarantees
-            // exclusive access to the waker at `INDEX`.
-            unsafe {
-                self.wake_by_ref(idx);
-            }
-
-            if let Err(s) = try_unlock(&self.state, state) {
-                state = s;
-            } else {
-                return;
-            }
-
-            // One more loop iteration is necessary because the waker was
-            // registered again and another notifier has failed to send a
-            // notification while the notifier lock was taken.
+            self.lock_free[0].notify();
         }
     }
 
@@ -136,120 +75,13 @@ impl DiatomicWaker {
     ///
     /// The `register`, `unregister` and `wait_until` methods cannot be used
     /// concurrently from multiple threads.
+    #[expect(clippy::out_of_bounds_indexing)]
     pub unsafe fn register(&self, waker: &Waker) {
-        // Transitions if the new waker is the same as the one currently stored.
-        //
-        // |  N  L  R  U  I  |  N  L  R  U  I  |
-        // |-----------------|-----------------|
-        // |  n  l  r  u  i  |  n  l  1  u  i  |
-        //
-        //
-        // Transitions if the new waker needs to be stored:
-        //
-        // Step 1 (only necessary if the state initially indicates R=U=1):
-        //
-        // |  N  L  R  U  I  |  N  L  R  U  I  |
-        // |-----------------|-----------------|
-        // |  n  l  r  u  i  |  0  l  0  u  i  |
-        //
-        // Step 2:
-        //
-        // |  N  L  R  U  I  |  N  L  R  U  I  |
-        // |-----------------|-----------------|
-        // |  n  l  r  u  i  |  n  l  1  1  i  |
-
-        // Ordering: Acquire ordering is necessary to synchronize with the
-        // Release unlocking operation in `notify`, which ensures that all calls
-        // to the waker in the redundant slot have completed.
-        let state = self.state.load(Ordering::Acquire);
-
-        // Compute the index of the waker that was most recently updated. Note
-        // that the value of `recent_idx` as computed below remains correct even
-        // if the state is stale since only this thread can store new wakers.
-        let mut idx = state & INDEX;
-        let recent_idx = if state & UPDATE == 0 {
-            idx
+        if impl_atomic::ENABLE {
+            self.atomic[0].register(waker);
         } else {
-            INDEX - idx
-        };
-
-        // Safety: it is safe to call `will_wake` since the registering thread
-        // is the only one allowed to mutate the wakers so there can be no
-        // concurrent mutable access to the waker.
-        let is_up_to_date = self.will_wake(recent_idx, waker);
-
-        // Fast path in case the waker is up to date.
-        if is_up_to_date {
-            // Set the `REGISTERED` flag. Ideally, the `NOTIFICATION` flag would
-            // be cleared at the same time to avoid a spurious wake-up, but it
-            // probably isn't worth the overhead of a CAS loop because having
-            // this flag set when calling `register` is very unlikely: it would
-            // mean that since the last call to `register`:
-            // 1) a notifier has been holding the lock continuously,
-            // 2) another notifier has tried and failed to take the lock, and
-            // 3) `unregister` was never called.
-            //
-            // Ordering: Acquire ordering synchronizes with the Release and
-            // AcqRel RMWs in `try_lock` (called by `notify`) and ensures that
-            // either the predicate set before the call to `notify` will be
-            // visible after the call to `register`, or the registered waker
-            // will be visible during the call to `notify` (or both). Note that
-            // Release ordering is not necessary since the waker has not changed
-            // and this RMW takes part in a release sequence headed by the
-            // initial registration of the waker.
-            self.state.fetch_or(REGISTERED, Ordering::Acquire);
-
-            return;
+            self.lock_free[0].register(waker);
         }
-
-        // The waker needs to be stored in the redundant slot.
-        //
-        // It is necessary to make sure that either the `UPDATE` or the
-        // `REGISTERED` flag is cleared to prevent concurrent access by a notifier
-        // to the redundant waker slot while the waker is updated.
-        //
-        // Note that only the thread registering the waker can set `REGISTERED`
-        // and `UPDATE` so even if the state is stale, observing `REGISTERED` or
-        // `UPDATE` as cleared guarantees that such flag is and will remain
-        // cleared until this thread sets them.
-        if state & (UPDATE | REGISTERED) == (UPDATE | REGISTERED) {
-            // Clear the `REGISTERED` and `NOTIFICATION` flags.
-            //
-            // Ordering: Acquire ordering is necessary to synchronize with the
-            // Release unlocking operation in `notify`, which ensures that all
-            // calls to the waker in the redundant slot have completed.
-            let state = self
-                .state
-                .fetch_and(!(REGISTERED | NOTIFICATION), Ordering::Acquire);
-
-            // It is possible that `UPDATE` was cleared and `INDEX` was switched
-            // by a notifier after the initial load of the state, so the waker
-            // index needs to be updated.
-            idx = state & INDEX;
-        }
-
-        // Always store the new waker in the redundant slot to avoid racing with
-        // a notifier.
-        let redundant_idx = 1 - idx;
-
-        // Store the new waker.
-        //
-        // Safety: it is safe to store the new waker in the redundant slot
-        // because the `REGISTERED` flag and/or the `UPDATE` flag are/is cleared
-        // so the notifier will not attempt to switch the waker.
-        self.set_waker(redundant_idx, waker.clone());
-
-        // Make the waker visible.
-        //
-        // Ordering: Acquire ordering synchronizes with the Release and AcqRel
-        // RMWs in `try_lock` (called by `notify`) and ensures that either the
-        // predicate set before the call to `notify` will be visible after the
-        // call to `register`, or the registered waker will be visible during
-        // the call to `notify` (or both). Since the waker has been modified
-        // above, Release ordering is also necessary to synchronize with the
-        // AcqRel RMW in `try_lock` (success case) and ensure that the
-        // modification to the waker is fully visible when notifying.
-        self.state.fetch_or(UPDATE | REGISTERED, Ordering::AcqRel);
     }
 
     /// Unregisters the waker.
@@ -263,21 +95,13 @@ impl DiatomicWaker {
     ///
     /// The `register`, `unregister` and `wait_until` methods cannot be used
     /// concurrently from multiple threads.
+    #[expect(clippy::out_of_bounds_indexing)]
     pub unsafe fn unregister(&self) {
-        // Transitions:
-        //
-        // |  N  L  R  U  I  |  N  L  R  U  I  |
-        // |-----------------|-----------------|
-        // |  n  l  r  u  i  |  0  l  0  u  i  |
-
-        // Modify the state. Note that the waker is not dropped: caching it can
-        // avoid a waker drop/cloning cycle (typically, 2 RMWs) in the frequent
-        // case when the next waker to be registered will be the same as the one
-        // being unregistered.
-        //
-        // Ordering: no waker was modified so Relaxed ordering is sufficient.
-        self.state
-            .fetch_and(!(REGISTERED | NOTIFICATION), Ordering::Relaxed);
+        if impl_atomic::ENABLE {
+            self.atomic[0].unregister();
+        } else {
+            self.lock_free[0].unregister();
+        }
     }
 
     /// Returns a future that can be `await`ed until the provided predicate
@@ -295,198 +119,11 @@ impl DiatomicWaker {
     {
         WaitUntil::new(self, predicate)
     }
-
-    /// Sets the waker at index `idx`.
-    ///
-    /// # Safety
-    ///
-    /// The caller must have exclusive access to the waker at index `idx`.
-    unsafe fn set_waker(&self, idx: usize, new: Waker) {
-        self.waker[idx].with_mut(|waker| (*waker) = Some(new));
-    }
-
-    /// Notify the waker at index `idx`.
-    ///
-    /// # Safety
-    ///
-    /// The waker at index `idx` cannot be modified concurrently.
-    unsafe fn wake_by_ref(&self, idx: usize) {
-        self.waker[idx].with(|waker| {
-            if let Some(waker) = &*waker {
-                waker.wake_by_ref();
-            }
-        });
-    }
-
-    /// Check whether the waker at index `idx` will wake the same task as the
-    /// provided waker.
-    ///
-    /// # Safety
-    ///
-    /// The waker at index `idx` cannot be modified concurrently.
-    unsafe fn will_wake(&self, idx: usize, other: &Waker) -> bool {
-        self.waker[idx].with(|waker| match &*waker {
-            Some(waker) => waker.will_wake(other),
-            None => false,
-        })
-    }
 }
 
 impl Default for DiatomicWaker {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-unsafe impl Send for DiatomicWaker {}
-unsafe impl Sync for DiatomicWaker {}
-
-/// Attempts to acquire the notifier lock and returns the current state upon
-/// success.
-///
-/// Acquisition of the lock will fail in the following cases:
-///
-/// * the `REGISTERED` flag is cleared, meaning that there is no need to wake
-///   and therefore no need to lock,
-/// * the lock is already taken, in which case the `NOTIFICATION` flag will be
-///   set if the `REGISTERED` flag is set.
-///
-/// If acquisition of the lock succeeds, the `REGISTERED` flag is cleared. If
-/// additionally the `UPDATE` flag was set, it is cleared and `INDEX` is
-/// flipped.
-///
-///  Transition table:
-///
-/// |  N  L  R  U  I  |  N  L  R  U  I  |
-/// |-----------------|-----------------|
-/// |  0  0  0  u  i  |  0  0  0  u  i  | (failure)
-/// |  0  0  1  0  i  |  0  1  0  0  i  | (success)
-/// |  0  0  1  1  i  |  0  1  0  0 !i  | (success)
-/// |  0  1  0  u  i  |  0  1  0  u  i  | (failure)
-/// |  n  1  1  u  i  |  1  1  1  u  i  | (failure)
-///
-fn try_lock(state: &AtomicUsize) -> Result<usize, ()> {
-    let mut old_state = state.load(Ordering::Relaxed);
-
-    loop {
-        if old_state & (LOCKED | REGISTERED) == REGISTERED {
-            // Success path.
-
-            // If `UPDATE` is set, clear `UPDATE` and flip `INDEX` with the xor
-            // mask.
-            let update_bit = old_state & UPDATE;
-            let xor_mask = update_bit | (update_bit >> 1);
-
-            // Set `LOCKED` and clear `REGISTERED` with the xor mask.
-            let xor_mask = xor_mask | LOCKED | REGISTERED;
-
-            let new_state = old_state ^ xor_mask;
-
-            // Ordering: Acquire is necessary to synchronize with the Release
-            // ordering in `register` so that the new waker, if any, is visible.
-            // Release ordering synchronizes with the Acquire and AcqRel RMWs in
-            // `register` and ensures that either the predicate set before the
-            // call to `notify` will be visible after the call to `register`, or
-            // the registered waker will be visible during the call to `notify`
-            // (or both).
-            match state.compare_exchange_weak(
-                old_state,
-                new_state,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return Ok(new_state),
-                Err(s) => old_state = s,
-            }
-        } else {
-            // Failure path.
-
-            // Set the `NOTIFICATION` bit if `REGISTERED` was set.
-            let registered_bit = old_state & REGISTERED;
-            let new_state = old_state | (registered_bit << 2);
-
-            // Ordering: Release ordering synchronizes with the Acquire and
-            // AcqRel RMWs in `register` and ensures that either the predicate
-            // set before the call to `notify` will be visible after the call to
-            // `register`, or the registered waker will be visible during the
-            // call to `notify` (or both).
-            match state.compare_exchange_weak(
-                old_state,
-                new_state,
-                Ordering::Release,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return Err(()),
-                Err(s) => old_state = s,
-            }
-        };
-    }
-}
-
-/// Attempts to release the notifier lock and returns the current state upon
-/// failure.
-///
-/// Release of the lock will fail if the `NOTIFICATION` flag is set because it
-/// means that, after the lock was taken, the registering thread has requested
-/// to be notified again and another notifier has subsequently requested that
-/// such notification be sent on its behalf; if additionally the `UPDATE` flag
-/// was set (i.e. a new waker is available), it is cleared and `INDEX` is
-/// flipped.
-///
-/// Transition table:
-///
-/// |  N  L  R  U  I  |  N  L  R  U  I  |
-/// |-----------------|-----------------|
-/// |  0  1  r  u  i  |  0  0  r  u  i  | (success)
-/// |  1  1  1  0  i  |  0  1  0  0  i  | (failure)
-/// |  1  1  1  1  i  |  0  1  0  0 !i  | (failure)
-///
-fn try_unlock(state: &AtomicUsize, mut old_state: usize) -> Result<(), usize> {
-    loop {
-        if old_state & NOTIFICATION == 0 {
-            // Success path.
-
-            let new_state = old_state & !LOCKED;
-
-            // Ordering: Release is necessary to synchronize with the Acquire
-            // ordering in `register` and ensure that the waker call has
-            // completed before a new waker is stored.
-            match state.compare_exchange_weak(
-                old_state,
-                new_state,
-                Ordering::Release,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return Ok(()),
-                Err(s) => old_state = s,
-            }
-        } else {
-            // Failure path.
-
-            // If `UPDATE` is set, clear `UPDATE` and flip `INDEX` with the xor mask.
-            let update_bit = old_state & UPDATE;
-            let xor_mask = update_bit | (update_bit >> 1);
-
-            // Clear `NOTIFICATION` and `REGISTERED` with the xor mask.
-            let xor_mask = xor_mask | NOTIFICATION | REGISTERED;
-
-            let new_state = old_state ^ xor_mask;
-
-            // Ordering: Release is necessary to synchronize with the Acquire
-            // ordering in `register` and ensure that the call to
-            // `Waker::wake_by_ref` has completed before a new waker is stored.
-            // Acquire ordering is in turn necessary to ensure that any newly
-            // registered waker is visible.
-            match state.compare_exchange_weak(
-                old_state,
-                new_state,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return Err(new_state),
-                Err(s) => old_state = s,
-            }
-        };
     }
 }
 

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -37,6 +37,7 @@ impl DiatomicWaker {
     }
 
     #[cfg(all(test, diatomic_waker_loom))]
+    #[expect(missing_docs)]
     pub fn new() -> Self {
         Self {
             atomic: [],


### PR DESCRIPTION
We add an `atomic` feature flag, which enables a dependency on `portable-atomic` to support an implementation of `DiatomicWaker` backed by 128-bit atomics.

We also bump the MSRV to 1.84; in theory one could reduce it to 1.56 when the `atomic` flag is not enabled.